### PR TITLE
rpc compiler: opt-in blocking api generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ subprojects {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 
-    ext['reactor-bom.version'] = 'Dysprosium-M3'
-    ext['rsocket.version'] = '1.0.0-RC2'
+    ext['reactor-bom.version'] = 'Dysprosium-RELEASE'
+    ext['rsocket.version'] = '1.0.0-RC5'
 
     ext['protobuf.version'] = '3.6.1'
     ext['log4j.version'] = '2.11.2'
@@ -52,8 +52,7 @@ subprojects {
     ext['hdrhistogram.version'] = '2.1.10'
 
     repositories {
-        jcenter()
-        maven { url 'https://repo.spring.io/milestone' }
+        mavenCentral()
         if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
             maven { url 'http://repo.spring.io/libs-snapshot' }
             maven { url 'https://oss.jfrog.org/oss-snapshot-local' }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.rsocket.rpc
-version=0.2.19
+version=0.2.20-SNAPSHOT

--- a/rsocket-rpc-protobuf/src/java_plugin/cpp/java_plugin.cpp
+++ b/rsocket-rpc-protobuf/src/java_plugin/cpp/java_plugin.cpp
@@ -82,12 +82,21 @@ class JavaRSocketRpcGenerator : public google::protobuf::compiler::CodeGenerator
     blocking_java_rsocket_rpc_generator::ProtoFlavor::NORMAL;
 
     bool disable_version = false;
+    bool generate_blocking_api = false;
+
     for (size_t i = 0; i < options.size(); i++) {
-        if (options[i].first == "lite") {
+        const string& option = options[i].first;
+        if (option == "lite") {
             flavor = blocking_java_rsocket_rpc_generator::ProtoFlavor::LITE;
-        } else if (options[i].first == "noversion") {
+        } else if (option == "noversion") {
             disable_version = true;
+        } else if (option == "generate-blocking-api") {
+            generate_blocking_api = true;
         }
+    }
+
+    if (!generate_blocking_api) {
+        return true;
     }
 
     string package_name = blocking_java_rsocket_rpc_generator::ServiceJavaPackage(file);


### PR DESCRIPTION
blocking api code generation is enabled with `generate-blocking-api` option. E.g. for gradle
```groovy
    plugins {
        rsocketRpc {
            artifact = "io.rsocket.rpc:rsocket-rpc-protobuf:${rsocketRpcVersion}"
        }
        generateProtoTasks {
            ofSourceSet('main')*.plugins {
                rsocketRpc {
                    option "generate-blocking-api"
                }
            }
        }
    }
```
closes #47