### PR TITLE
feat: set build number for artifactory upload

### DIFF
--- a/artifactory.gradle
+++ b/artifactory.gradle
@@ -33,6 +33,7 @@ if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey')) {
                     defaults {
                         publications('maven')
                     }
+                    clientConfig.info.setBuildNumber('' + project.property('buildNumber'))
                 }
             }
         }

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -20,7 +20,7 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ] && [ "$bin
 
     echo -e "Building Tag $TRAVIS_REPO_SLUG/$TRAVIS_TAG"
     ./gradlew \
-        -Pversion="$TRAVIS_TAG" -Pstage="$TRAVIS_BUILD_STAGE_NAME" \
+        -Pversion="$TRAVIS_TAG" -Pstage="$TRAVIS_BUILD_STAGE_NAME" -PbuildNumber="$TRAVIS_BUILD_NUMBER" \
         -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" \
         -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" \
         -PvcProtobufLibs="/c/Program Files/protobuf/lib" -PvcProtobufInclude="/c/Program Files/protobuf/include" \


### PR DESCRIPTION
today we re-publish the SNAPSHOT artifacts 3 times, and the last build wins, which means 2 of 3 of the plugins are randomly, never available to be used unless you start pinning specific builds of snapshots in your project.

Ideally the mac and windows builds would only create their plugins - then the linux build would compile all the things, download the other two plugins, and publish all the artifacts 1 time - enabling the snapshot publishing to have 1 consistent build number.

Travis doesn't provide us with any storage, so we'd be forced to use something like S3 to accomplish this.

In the meanwhile, because we use Artifactory, in theory we can override the build number on all 3 publishes, and maybe avoid all this work. Of course what I really think is going to happen is that Artifactory is either going to vomit when we try re-uploading the same artifact with the same build number - or none of this will matter because the timestamps will still be wrong.