### PR TITLE
temporary use specific rsocket build with prioritization

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group=io.rsocket.rpc
 version=0.3.0
 
 reactorBomVersion=Dysprosium-RELEASE
-rsocketVersion=1.0.0-RC6-SNAPSHOT
+rsocketVersion=1.0.0-RC6-bugfix-prioritization-SNAPSHOT
 graphqlVersion=11.0
 protobufVersion=3.7.1
 log4jVersion=2.12.1


### PR DESCRIPTION
This PR provides fixes for the build process as well as some changes in dependency management.

Also, this PR is temporarily using specific RSocket version related to prioritization

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>